### PR TITLE
Add a SECURITY.md file

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,47 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+This is a short excerpt of our [security bounty program](https://yoast.com/security-program/).
+
+The following plugins are within the scope of this program:
+* Yoast SEO Free
+* Duplicate Post
+* Yoast SEO Premium
+* Local SEO
+* WooCommerce SEO
+* Video SEO
+* News SEO
+* Yoast SEO for Shopify
+* Yoast ACF Analysis
+* Custom Field Finder
+* WHIP
+* Test Helper
+
+Other packages, services or infrastructure in the Yoast organisation are not eligible for bounties under the program.
+Responsible disclosure of discovered vulnerabilities in those, is, of course, still very much appreciated.
+
+### The rules of the bounty program
+- Please provide detailed reports with reproducible steps. If the report is not detailed enough to reproduce the issue, the issue will not be eligible for a reward.
+- Submit one vulnerability per report, unless you need to chain vulnerabilities to provide impact.
+- For duplicates, we only award the first report that was received (provided that it can be fully reproduced).
+- Multiple vulnerabilities caused by one underlying issue will only be eligible for one reward.
+- When testing has an overlap with systems or services not owned by you, the tester, make a good faith effort to avoid privacy violations, destruction of data, and interruption or degradation of that service. Only interact with accounts you own or with the explicit permission of the account holder.
+
+### Disclosure Policy
+Please do not discuss any vulnerabilities (even resolved ones) without express consent.
+
+### Submit your report
+When you've found a security issue that abides by the rules and scope of this project, please submit the report to us via security@yoast.com. In your mail, make sure to include:
+
+- the calculation of the CVSS (using the [CVSS calculator](https://www.first.org/cvss/calculator/3.0));
+- the impact of the issue;
+- a detailed guide on how to reproduce the issue;
+- the email address you used to create a MyYoast-account (if applicable).
+
+### After your submission
+We will make a best effort to meet the following response targets for security reports:
+
+- Time to first response (from report submit) - 3 business days
+- Time to triage (from report submit) - 10 business days
+- Time to bounty (from triage) - 10 business days


### PR DESCRIPTION
... containing information about the security bounty program and how to report security issues.

The file is placed in the `.github` repository, which means that it will automatically be used by all repos which don't have an explicit `SECURITY.md` file in the repo itself.

Once this PR has been merged, the `SECURITY.md` file in those repos which currently have one can be removed, so all repos display the same security information.

Refs:
* https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository
* https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file