### PR TITLE
QA: add reusable actionlint workflow

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,0 +1,15 @@
+name: QA
+
+on:
+  # Run on all pushes and on all pull requests.
+  push:
+  pull_request:
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
+
+jobs:
+  actionlint:
+    name: 'Lint GH Action workflows'
+    uses: ./.github/workflows/reusable-actionlint.yml
+    with:
+      args: '-verbose'

--- a/.github/workflows/reusable-actionlint.yml
+++ b/.github/workflows/reusable-actionlint.yml
@@ -1,0 +1,41 @@
+name: GH Actions Lint
+
+on:
+  workflow_call:
+    inputs:
+      shellcheck:
+        description: 'Whether to enable shellcheck. Defaults to enabled.'
+        type: boolean
+        required: false
+        default: true
+      pyflakes:
+        description: 'Whether to enable pyflakes. Defaults to enabled.'
+        type: boolean
+        required: false
+        default: true
+      args:
+        description: 'Command line arguments to pass to the actionlint command.'
+        type: string
+        required: false
+        default: ''
+
+jobs:
+  actionlint:
+    name: 'Actionlint'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Add problem matcher
+        if: ${{ github.event_name == 'pull_request' }}
+        shell: bash
+        run: |
+          curl -o actionlint-matcher.json https://raw.githubusercontent.com/rhysd/actionlint/main/.github/actionlint-matcher.json
+          echo "::add-matcher::actionlint-matcher.json"
+
+      - name: Check workflow files
+        uses: docker://rhysd/actionlint:latest
+        with:
+          args: -color ${{ inputs.args }} ${{ inputs.shellcheck == false && '-shellcheck=' || '' }} ${{ inputs.pyflakes == false && '-pyflakes=' || '' }}


### PR DESCRIPTION
The Actionlint package can check workflows for GH Actions for common errors and potential improvements.

This commit adds:
1. A reusable workflow to run actionlint on all workflows in a repo. The workflow is set up to allows for optionally disabling the included shellcheck and/or pyflakes checkers. It also has an input field to, optionally, allow for passing additional command line arguments to the `actionlint` command.
2. A regular workflow which _uses_ the reusable workflow to check all workflows in _this_ repo.

Keep in mind: this repo will host a number of _reusable_ workflows, which will not be used by this repo. Errors in those workflows would break the CI of packages _using_ the reusable workflows, but can easily go unnoticed when the changes are made as most of the reusable workflows will not be used by _this repo_.

By running the actionlinter over all workflows in this repo, we can at least safeguard against syntax errors and other common problems, though logic errors may still go unnoticed.

Refs:
* https://github.com/rhysd/actionlint
* https://github.com/rhysd/actionlint/blob/v1.7.4/docs/checks.md