### PR TITLE
Dependabot: remove reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,5 +14,3 @@ updates:
       prefix: "GH Actions:"
     labels:
       - "chores/QA"
-    reviewers:
-      - "jrfnl"


### PR DESCRIPTION
Support for the `reviewers` key in `dependabot.yml` files is being removed by GitHub on May 20th 2025.

The recommendation is to have a `CODEOWNERS` file to set reviewers instead.

For now, this commit removes the `reviewers` key from the `dependabot.yml` file without replacing it. That should prevent comments being left in PRs by the dependabot bot account about the field no longer being supported.

Ref:
* https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/
* https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-location