### PR TITLE
GH Actions: always use `env` for handling user input

### DIFF
--- a/.github/workflows/reusable-merge-conflict-check.yml
+++ b/.github/workflows/reusable-merge-conflict-check.yml
@@ -40,12 +40,14 @@ jobs:
     steps:
       - name: "Create label if it doesn't exist"
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          DIRTY_LABEL: ${{ inputs.dirtyLabel }}
         with:
           script: |
             try {
               await github.rest.issues.createLabel({
                 ...context.repo,
-                name: "${{ inputs.dirtyLabel }}"
+                name: "${DIRTY_LABEL}"
               });
             } catch(e) {
               // Ignore if labels exist already.


### PR DESCRIPTION
> GitHub Actions allows workflows to define template expansions, which occur within special `${{ ... }}` delimiters. These expansions happen before workflow and job execution, meaning the expansion of a given expression appears verbatim in whatever context it was performed in.
>
> Template expansions aren't syntax-aware, meaning that they can result in unintended shell injection vectors. This is especially true when they're used with attacker-controllable expression contexts, such as `github.event.issue.title` (which the attacker can fully control by supplying a new issue title).

Ref:
* https://securitylab.github.com/resources/github-actions-untrusted-input/
* https://docs.zizmor.sh/audits/#template-injection