### PR TITLE
Mark merge conflict comments as resolved once the conflict is fixed

### DIFF
--- a/.github/workflows/reusable-merge-conflict-check.yml
+++ b/.github/workflows/reusable-merge-conflict-check.yml
@@ -105,11 +105,14 @@ jobs:
               return;
             }
 
+            // Walk the comments newest first, as the conflict comment is usually one of the
+            // most recent ones. On PRs with a long history this normally finds it in the
+            // first page instead of paging through the entire comment history.
             const query = `
-              query prComments($owner: String!, $repo: String!, $number: Int!, $after: String) {
+              query prComments($owner: String!, $repo: String!, $number: Int!, $before: String) {
                 repository(owner: $owner, name: $repo) {
                   pullRequest(number: $number) {
-                    comments(first: 100, after: $after) {
+                    comments(last: 100, before: $before) {
                       nodes {
                         id
                         body
@@ -117,8 +120,8 @@ jobs:
                         viewerDidAuthor
                       }
                       pageInfo {
-                        endCursor
-                        hasNextPage
+                        startCursor
+                        hasPreviousPage
                       }
                     }
                   }
@@ -137,14 +140,14 @@ jobs:
             `;
 
             for (const number of cleanPrNumbers) {
-              let after = null;
-              let hasNextPage = true;
+              let before = null;
+              let hasPreviousPage = true;
 
-              while (hasNextPage) {
+              while (hasPreviousPage) {
                 const response = await github.graphql(query, {
                   ...context.repo,
                   number,
-                  after,
+                  before,
                 });
 
                 const { nodes, pageInfo } = response.repository.pullRequest.comments;
@@ -154,8 +157,8 @@ jobs:
                 // the same page forever. Checked before processing so a stuck cursor cannot
                 // cause the same page to be handled twice.
                 const cursorStuck =
-                  pageInfo.hasNextPage &&
-                  (!pageInfo.endCursor || pageInfo.endCursor === after);
+                  pageInfo.hasPreviousPage &&
+                  (!pageInfo.startCursor || pageInfo.startCursor === before);
 
                 if (cursorStuck) {
                   core.warning(
@@ -188,7 +191,7 @@ jobs:
                   }
                 }
 
-                hasNextPage = pageInfo.hasNextPage && !cursorStuck;
-                after = pageInfo.endCursor;
+                hasPreviousPage = pageInfo.hasPreviousPage && !cursorStuck;
+                before = pageInfo.startCursor;
               }
             }

--- a/.github/workflows/reusable-merge-conflict-check.yml
+++ b/.github/workflows/reusable-merge-conflict-check.yml
@@ -166,6 +166,10 @@ jobs:
                 // Only minimize this workflow's own, not yet minimized, conflict comments.
                 // Matching on the exact comment body prevents unrelated comments from
                 // being hidden if the bot posted other comments on the same PR.
+                // Note that `viewerDidAuthor` is scoped to the identity behind the token,
+                // which is the default GITHUB_TOKEN (github-actions[bot]) here. Passing a
+                // PAT or app token to this step would widen this to that identity's
+                // comments, so don't set `github-token` without revisiting this filter.
                 const staleComments = nodes.filter(
                   (comment) =>
                     comment.viewerDidAuthor &&

--- a/.github/workflows/reusable-merge-conflict-check.yml
+++ b/.github/workflows/reusable-merge-conflict-check.yml
@@ -31,12 +31,29 @@ on:
         type: string
         required: false
         default: ''
+      minimizeCommentOnClean:
+        description: "Whether to mark the `commentOnDirty` comment as resolved once the merge conflict is resolved."
+        type: boolean
+        required: false
+        default: true
+
+# Default to no permissions at all; the job below opts in to only what it needs.
+permissions: {}
 
 jobs:
   check-prs:
     name: Merge conflict check
 
     runs-on: ubuntu-latest
+
+    # Safety net: the merge conflict check retries for at most ~10 minutes
+    # (retryAfter 120s * retryMax 5), so anything beyond this is a runaway job.
+    timeout-minutes: 20
+
+    permissions:
+      issues: write # Needed to create the dirty label and to add/remove labels on PRs.
+      pull-requests: write # Needed to comment and to mark those comments as resolved.
+
     steps:
       - name: "Create label if it doesn't exist"
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -56,6 +73,7 @@ jobs:
             }
 
       - name: Check PRs for merge conflicts
+        id: check
         uses: eps1lon/actions-label-merge-conflict@0273be72a0bbd58fcd71d0d6c02c209b50d1e5e1 # v3.1.0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
@@ -63,3 +81,110 @@ jobs:
           removeOnDirtyLabel: ${{ inputs.removeOnDirtyLabel }}
           commentOnDirty: ${{ inputs.commentOnDirty }}
           commentOnClean: ${{ inputs.commentOnClean }}
+
+      - name: "Mark merge conflict comments as resolved for PRs which are no longer conflicting"
+        if: ${{ inputs.minimizeCommentOnClean && inputs.commentOnDirty != '' }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          # Passed via the environment, never interpolated into the script, as these are
+          # caller-controlled inputs and interpolation would allow script injection.
+          DIRTY_STATUSES: ${{ steps.check.outputs.prDirtyStatuses }}
+          COMMENT_ON_DIRTY: ${{ inputs.commentOnDirty }}
+        with:
+          script: |
+            const dirtyStatuses = JSON.parse(process.env.DIRTY_STATUSES || '{}');
+            const commentOnDirty = process.env.COMMENT_ON_DIRTY;
+
+            // Only PRs which the check found to be conflict-free need cleaning up.
+            const cleanPrNumbers = Object.entries(dirtyStatuses)
+              .filter(([, isDirty]) => isDirty === false)
+              .map(([number]) => Number(number));
+
+            if (cleanPrNumbers.length === 0) {
+              core.info('No conflict-free PRs to clean up.');
+              return;
+            }
+
+            const query = `
+              query prComments($owner: String!, $repo: String!, $number: Int!, $after: String) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    comments(first: 100, after: $after) {
+                      nodes {
+                        id
+                        body
+                        isMinimized
+                        viewerDidAuthor
+                      }
+                      pageInfo {
+                        endCursor
+                        hasNextPage
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+
+            const mutation = `
+              mutation minimize($id: ID!) {
+                minimizeComment(input: { subjectId: $id, classifier: RESOLVED }) {
+                  minimizedComment {
+                    isMinimized
+                  }
+                }
+              }
+            `;
+
+            for (const number of cleanPrNumbers) {
+              let after = null;
+              let hasNextPage = true;
+
+              while (hasNextPage) {
+                const response = await github.graphql(query, {
+                  ...context.repo,
+                  number,
+                  after,
+                });
+
+                const { nodes, pageInfo } = response.repository.pullRequest.comments;
+
+                // Guard against a malformed response which claims another page but hands
+                // back no cursor, or the same cursor again. Either would have us re-request
+                // the same page forever. Checked before processing so a stuck cursor cannot
+                // cause the same page to be handled twice.
+                const cursorStuck =
+                  pageInfo.hasNextPage &&
+                  (!pageInfo.endCursor || pageInfo.endCursor === after);
+
+                if (cursorStuck) {
+                  core.warning(
+                    `Pagination for PR #${number} did not advance; stopping after this page to avoid an endless loop.`
+                  );
+                }
+
+                // Only minimize this workflow's own, not yet minimized, conflict comments.
+                // Matching on the exact comment body prevents unrelated comments from
+                // being hidden if the bot posted other comments on the same PR.
+                const staleComments = nodes.filter(
+                  (comment) =>
+                    comment.viewerDidAuthor &&
+                    !comment.isMinimized &&
+                    comment.body.trim() === commentOnDirty.trim()
+                );
+
+                for (const comment of staleComments) {
+                  try {
+                    await github.graphql(mutation, { id: comment.id });
+                    core.info(`Marked comment ${comment.id} on PR #${number} as resolved.`);
+                  } catch (e) {
+                    core.warning(
+                      `Could not minimize comment ${comment.id} on PR #${number}: ${e.message}`
+                    );
+                  }
+                }
+
+                hasNextPage = pageInfo.hasNextPage && !cursorStuck;
+                after = pageInfo.endCursor;
+              }
+            }

--- a/.github/workflows/reusable-merge-conflict-check.yml
+++ b/.github/workflows/reusable-merge-conflict-check.yml
@@ -40,12 +40,16 @@ jobs:
     steps:
       - name: "Create label if it doesn't exist"
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          # Passed via the environment, never interpolated into the script, as this is a
+          # caller-controlled input and interpolation would allow script injection.
+          DIRTY_LABEL: ${{ inputs.dirtyLabel }}
         with:
           script: |
             try {
               await github.rest.issues.createLabel({
                 ...context.repo,
-                name: "${{ inputs.dirtyLabel }}"
+                name: process.env.DIRTY_LABEL
               });
             } catch(e) {
               // Ignore if labels exist already.

--- a/.github/workflows/reusable-merge-conflict-check.yml
+++ b/.github/workflows/reusable-merge-conflict-check.yml
@@ -167,8 +167,8 @@ jobs:
                 }
 
                 // Only minimize this workflow's own, not yet minimized, conflict comments.
-                // Matching on the exact comment body prevents unrelated comments from
-                // being hidden if the bot posted other comments on the same PR.
+                // Matching on the comment body (after trimming leading/trailing whitespace)
+                // prevents unrelated comments from being hidden if the bot posted other comments on the same PR.
                 // Note that `viewerDidAuthor` is scoped to the identity behind the token,
                 // which is the default GITHUB_TOKEN (github-actions[bot]) here. Passing a
                 // PAT or app token to this step would widen this to that identity's

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ The following re-usable workflows are available:
     - `commentOnClean`: Optional. Comment to add when the pull request is not conflicting anymore. Supports markdown.
         Defaults to _no comment_.
     - `minimizeCommentOnClean`: Optional. Whether to mark the `commentOnDirty` comment as resolved (collapsed) once the
-        merge conflict has been resolved. Only comments posted by this workflow which exactly match the `commentOnDirty`
-        text are minimized. Has no effect when `commentOnDirty` is empty. Defaults to 'true'.
+        merge conflict has been resolved. Only comments posted by this workflow whose body matches `commentOnDirty`
+        (ignoring leading/trailing whitespace) are minimized. Has no effect when `commentOnDirty` is empty. Defaults to 'true'.
         Note that changing `commentOnDirty` will leave already posted comments unmatched, so those will stay visible
         instead of being collapsed.
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ The following re-usable workflows are available:
         Defaults to: _"A merge conflict has been detected for the proposed code changes in this PR. Please resolve the conflict by either rebasing the PR or merging in changes from the base branch."_.
     - `commentOnClean`: Optional. Comment to add when the pull request is not conflicting anymore. Supports markdown.
         Defaults to _no comment_.
+    - `minimizeCommentOnClean`: Optional. Whether to mark the `commentOnDirty` comment as resolved (collapsed) once the
+        merge conflict has been resolved. Only comments posted by this workflow which exactly match the `commentOnDirty`
+        text are minimized. Has no effect when `commentOnDirty` is empty. Defaults to 'true'.
 
 
 ## A .github repository with versioning ?

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ The following re-usable workflows are available:
     - `minimizeCommentOnClean`: Optional. Whether to mark the `commentOnDirty` comment as resolved (collapsed) once the
         merge conflict has been resolved. Only comments posted by this workflow which exactly match the `commentOnDirty`
         text are minimized. Has no effect when `commentOnDirty` is empty. Defaults to 'true'.
+        Note that changing `commentOnDirty` will leave already posted comments unmatched, so those will stay visible
+        instead of being collapsed.
 
 
 ## A .github repository with versioning ?


### PR DESCRIPTION

## Summary

The merge conflict check already removes the `merge conflict` label once a PR stops conflicting, but the comment explaining the conflict stayed visible. That left stale, misleading noise on PRs that were no longer conflicting.

This collapses that comment as `RESOLVED` once the conflict is gone, which is the same result as using the "Hide comment" UI manually.

While working on this, `zizmor` flagged a pre-existing **high severity** script injection vulnerability in the "Create label" step, which is fixed here as a separate commit.

## Changes

### Security fix (39ad453)

* The "Create label if it doesn't exist" step interpolated the caller-controlled `${{ inputs.dirtyLabel }}` directly into an `actions/github-script` body. Since this workflow is reusable and is typically called from `pull_request_target` with a write-scoped token, a crafted label name could break out of the string literal and execute arbitrary code in the calling repository. The input is now passed through the environment and read via `process.env`, so it is always treated as inert data.

### Auto-resolve comments (a244059)

* Mark the `commentOnDirty` comment as resolved via the GraphQL `minimizeComment` mutation once a PR is no longer conflicting.
* Only comments which were authored by this workflow, are not already minimized, and whose body matches `commentOnDirty` exactly are minimized.
* Reuses the check step's existing `prDirtyStatuses` output to decide which PRs are clean, so no extra merge state queries are needed.
* Added `timeout-minutes: 20` as a last line of defense against a runaway job.
* Declared permissions explicitly: `permissions: {}` at workflow level, with the job opting in to only `issues: write` and `pull-requests: write`. This *narrows* the token compared to the previous implicit defaults.
